### PR TITLE
add fahrenheit support via url query string

### DIFF
--- a/p_weather/openweathermap.py
+++ b/p_weather/openweathermap.py
@@ -21,7 +21,7 @@ class WeatherInfo():
     FORECAST_PERIOD_HOURS = 3
 
 
-    def __init__(self,fdata):
+    def __init__(self,fdata, fahrenheight=False):
         self.t =  datetime.datetime.fromtimestamp(int(fdata['dt']))
         self.id = int(fdata['weather'][0]['id'])
 
@@ -60,8 +60,10 @@ class WeatherInfo():
         else:
             self.winddeg = 0.0
 
-
         self.temp = float(fdata['main']['temp']) - WeatherInfo.KTOC
+
+        if fahrenheight:
+            self.temp = self.temp * (9/5) + 32
 
 
     def Print(self):
@@ -92,10 +94,11 @@ class OpenWeatherMap():
     FILETOOOLD_SEC = 15*60 # 15 mins
     TOOMUCHTIME_SEC = 4*60*60 # 4 hours 
 
-    def __init__(self,apikey:str,latitude:float,longitude:float,rootdir:str=""):
+    def __init__(self,apikey:str,latitude:float,longitude:float,rootdir:str="",fahrenheight=False):
 
         self.latitude = latitude
         self.longitude = longitude
+        self.fahrenheight = fahrenheight
 
         reqstr = "lat=%.4f&lon=%.4f&mode=json&APPID=%s" % (self.LAT,self.LON,apikey)
         self.URL_FOREAST = self.OWMURL+"forecast?"+reqstr
@@ -169,14 +172,14 @@ class OpenWeatherMap():
     def FromJSON(self,data_curr,data_fcst):
         self.f = []
         cdata = data_curr
-        f = WeatherInfo(cdata)
+        f = WeatherInfo(cdata, self.fahrenheight)
         self.f.append(f)
         if not ('list' in data_fcst):
             return False
         for fdata in data_fcst['list']:
             if not WeatherInfo.Check(fdata):
                 continue
-            f = WeatherInfo(fdata)
+            f = WeatherInfo(fdata, self.fahrenheight)
             self.f.append(f)
         return True
 

--- a/weather_landscape.py
+++ b/weather_landscape.py
@@ -31,8 +31,8 @@ class WeatherLandscape:
 
 
 
-    def MakeImage(self)->Image:
-        owm = OpenWeatherMap(secrets.OWM_KEY,secrets.OWM_LAT,secrets.OWM_LON,self.TMP_DIR)
+    def MakeImage(self, fahrenheit=False)->Image:
+        owm = OpenWeatherMap(secrets.OWM_KEY,secrets.OWM_LAT,secrets.OWM_LON,self.TMP_DIR, fahrenheit)
         owm.FromAuto()
 
         img = Image.open(self.TEMPLATE_FILENAME)


### PR DESCRIPTION
resolves https://github.com/lds133/weather_landscape/issues/10

Including a query string of `?fahrenheit=true` on the end of the url will now cause the app to generate and load images using Fahrenheit for temperature instead of Celsius. Omitting the query string will still serve Celsius, so existing default behavior does not change.

This also fixes a minor bug where if no path was matched, the `403` response wasn't actually sent.

before:

```
$ curl -v http://localhost:3355/oops
*   Trying 127.0.0.1:3355...
* Connected to localhost (127.0.0.1) port 3355 (#0)
> GET /oops HTTP/1.1
> Host: localhost:3355
> User-Agent: curl/7.88.1
> Accept: */*
> 
* Empty reply from server
* Closing connection 0
curl: (52) Empty reply from server
```

after

```
$ curl -v http://localhost:3355/oops
*   Trying 127.0.0.1:3355...
* Connected to localhost (127.0.0.1) port 3355 (#0)
> GET /oops HTTP/1.1
> Host: localhost:3355
> User-Agent: curl/7.88.1
> Accept: */*
> 
* HTTP 1.0, assume close after body
< HTTP/1.0 403 Forbidden
< Server: BaseHTTP/0.6 Python/3.11.0
< Date: Thu, 13 Feb 2025 08:48:06 GMT
< 
* Closing connection 0
```