### PR TITLE
Fix 403 response

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -75,6 +75,7 @@ class WeatherLandscapeServer(BaseHTTPRequestHandler):
             
         print("Path not accessible:",self.path)
         self.send_response(403)
+        self.end_headers()
 
 
 


### PR DESCRIPTION
Let me know if you'd rather this target the `main` branch, it's the same behavior in both.

I noticed the `403` responses were resulting in empty responses from the server. Ex:

```
$ curl -v http://localhost:3355/oops
*   Trying 127.0.0.1:3355...
* Connected to localhost (127.0.0.1) port 3355 (#0)
> GET /oops HTTP/1.1
> Host: localhost:3355
> User-Agent: curl/7.88.1
> Accept: */*
> 
* Empty reply from server
* Closing connection 0
curl: (52) Empty reply from server
```

[The docs mention](https://docs.python.org/3/library/http.server.html#http.server.BaseHTTPRequestHandler.send_response) needing an explicit call to `end_headers()` when using `send_response()`.

After this change, the `403` is returned:

```
$ curl -v http://localhost:3355/oops
*   Trying 127.0.0.1:3355...
* Connected to localhost (127.0.0.1) port 3355 (#0)
> GET /oops HTTP/1.1
> Host: localhost:3355
> User-Agent: curl/7.88.1
> Accept: */*
> 
* HTTP 1.0, assume close after body
< HTTP/1.0 403 Forbidden
< Server: BaseHTTP/0.6 Python/3.11.0
< Date: Mon, 17 Feb 2025 04:49:01 GMT
< 
* Closing connection 0
```