### PR TITLE
Add support for Waveshare 2.9" e-Paper V2 (GDEY029T94) with partial refresh

### DIFF
--- a/esp32/board/appconfig.py
+++ b/esp32/board/appconfig.py
@@ -1,10 +1,39 @@
 
 class AppConfig:
-    
+
     TITLE = "WebFrame"
     
     VERSION = "1.2 MAR 2025" 
+
+    # ===== EPD Driver Selection =====
+    # Specify driver module name (without .py)
+    # Examples:
+    #   "epaper2in9"
+    #   "epaper2in9_V2"
+    EPD_DRIVER = "epaper2in9"
+
+    # Driver-specific extended configurations
+    DRIVER_EXTRAS = {
+        "epaper2in9_V2": {
+            # Number of partial updates before one full refresh to clear ghosting
+            "FULL_REFRESH_INTERVAL": 15,
+            # "light" for keeping RAM/variables, "deep" for maximum power saving
+            "SLEEP_MODE": "light"
+        }
+    }
     
+    # Enable debug overlay on display (refresh count and server timestamp)
+    DEBUG_OVERLAY = False
+
+    # ===== SPI Configuration =====
+    SPI_ID = 2
+    SPI_BAUDRATE = 4000000
+    SPI_POLARITY = 0
+    SPI_PHASE = 0
+    SPI_BITS = 8
+    SPI_FIRSTBIT = 0
+
+    # ===== Pin configuration =====
     PIN_CLK = 18
     PIN_DIN = 23 # MOSI
     PIN_DOUT = 19 # MISO, not used
@@ -15,16 +44,16 @@ class AppConfig:
     
     PIN_LED = 2
     
-    
+    # ===== Image reload control =====
     IMAGE_RELOAD_PERIOD_MS = 15*60*1000
     IMAGE_RELOAD_TIMEOUT_MS = 60*60*1000
 
-
+    # ===== Display configuration =====
     SCR_WIDTH = 128
     SCR_HEIGHT = 296
     SCR_BYTES_PER_LINE = int(SCR_WIDTH/8)
     
-
+    # ===== Network =====
     AP_SSID = '<your wifi ssid>'
     AP_PASS = '<your wifi password>'
   
@@ -38,6 +67,7 @@ class AppConfig:
     
     def print(self):
         print("***",self.TITLE,"***    Ver. ",self.VERSION)
+        print("EPD Driver =", self.EPD_DRIVER)
         print("EInk ",self.SCR_WIDTH,"x",self.SCR_HEIGHT)
         print("Pin CLK =", self.PIN_CLK)
         print("Pin DIN =", self.PIN_DIN) 

--- a/esp32/board/eink.py
+++ b/esp32/board/eink.py
@@ -1,6 +1,6 @@
 from machine import Pin, SPI
+import machine
 import time
-from epaper2in9 import EPD
 from screenbuffer import Screen
 from imagecomparer import ImageComparer
 
@@ -8,16 +8,14 @@ from imagecomparer import ImageComparer
 
 
 class EInk:
-    
-    
     def __init__(self,appcfg):
         self.cfg = appcfg
-        spi = SPI(  2,
-                    baudrate=80000000,
-                    polarity=0,
-                    phase=0,
-                    bits=8,
-                    firstbit=0,
+        spi = SPI(  appcfg.SPI_ID,
+                    baudrate=appcfg.SPI_BAUDRATE,
+                    polarity=appcfg.SPI_POLARITY,
+                    phase=appcfg.SPI_PHASE,
+                    bits=appcfg.SPI_BITS,
+                    firstbit=appcfg.SPI_FIRSTBIT,
                     sck=Pin(appcfg.PIN_CLK),
                     mosi=Pin(appcfg.PIN_DIN),
                     miso=Pin(appcfg.PIN_DOUT))
@@ -26,13 +24,31 @@ class EInk:
         dc = Pin(appcfg.PIN_DC,Pin.OUT)
         rst = Pin(appcfg.PIN_RST,Pin.OUT)
         busy = Pin(appcfg.PIN_BUSY,Pin.IN)
-        self.dev = EPD(spi, cs, dc, rst, busy)
+
+        # Dynamic EPD Driver Loading
+        try:
+            module = __import__(self.cfg.EPD_DRIVER)
+            EPD = getattr(module, "EPD")
+        except Exception as e:
+            raise RuntimeError("Failed to load EPD driver: " + str(e))
+        
+        try:
+            self.dev = EPD(spi, cs, dc, rst, busy, self.cfg) # V2 Style
+        except TypeError:
+            self.dev = EPD(spi, cs, dc, rst, busy) # V1 Style fallback
+            
         self.dev.init()
         print("EInk init")
-        
+
+        # Get driver generation (Default to 1 if not specified)
+        self.gen = getattr(self.dev, 'GENERATION', 1)
+
         self.scr = Screen(appcfg)
         self.cmp = ImageComparer()
-
+        
+        # State management for partial updates
+        self.old_data = None
+        self.sleep_mode = self.cfg.DRIVER_EXTRAS.get(self.cfg.EPD_DRIVER, {}).get("SLEEP_MODE", "deep")
         
     def clear(self):
         self.scr.clear()        
@@ -40,26 +56,63 @@ class EInk:
     def update(self,isforceupdate=False):
         self.show(self.scr.data,isforceupdate)
         
-        
-    def show(self,data,isforceupdate=False)->bool: 
+    def show(self, data, isforceupdate=False, update_time="") -> bool: 
+        """
+        Displays image data. Handles V1/V2 driver differences automatically.
+        """
+        # Change detection
         isthesame = self.cmp.check(data)
         if (isthesame) and (not isforceupdate):
-            print("EInk upadate skipped")
+            print("EInk update skipped: No changes detected")
             return False
-        self.dev.set_frame_memory(data, 0, 0, self.cfg.SCR_WIDTH, self.cfg.SCR_HEIGHT)
-        self.dev.display_frame()
+
+        if self.gen >= 2:
+            print("Using V2 strategy (Unified refresh)")
+            
+            # Overlay debug info onto the current screen buffer
+            self.dev.update_time = update_time
+            self.scr.scrbuf = bytearray(data)
+            
+            # Draw debug info (refresh count and server timestamp) onto screen buffer
+            if self.cfg.DEBUG_OVERLAY and hasattr(self.dev, 'draw_debug_overlay'):
+                self.dev.draw_debug_overlay(self.scr)
+            
+            # Use the buffer that now contains both image and debug text
+            current_frame = self.scr.data
+            
+            # Determine refresh mode based on data availability
+            needs_full = (isforceupdate or (self.old_data is None))
+
+            # Wake up the panel
+            self.dev.init() 
+
+            # Refresh Control Logic
+            if needs_full:
+                # Ensure the driver performs a clean, full refresh
+                self.dev.refresh_count = 0
+
+            # Execute Display Update
+            self.dev.display_frame(current_frame, self.old_data)
+            self.old_data = bytearray(current_frame)
+            
+        else:
+            # Generation 1 Strategy (Legacy)
+            print("Using V1 strategy (Split-method refresh)")
+            self.dev.set_frame_memory(data, 0, 0, self.cfg.SCR_WIDTH, self.cfg.SCR_HEIGHT)
+            self.dev.display_frame()
+            self.old_data = None
+
         return True
-        
         
     def print(self,text):
         self.scr.print(text)
-        
-        
-        
+             
     def printat(self,text,x,y):
         self.scr.printat(text,x,y)
-        
-        
-        
-        
-        
+
+    def sleep_panel(self):
+        if hasattr(self.dev, 'sleep'):
+            try:
+                self.dev.sleep()
+            except Exception as e:
+                print("Warning: EPD sleep failed:", e)

--- a/esp32/board/epaper2in9_V2.py
+++ b/esp32/board/epaper2in9_V2.py
@@ -1,0 +1,283 @@
+"""
+MicroPython Waveshare 2.9" Black/White GDEY029T94 e-paper display driver
+https://github.com/mcauser/micropython-waveshare-epaper
+
+MIT License
+Copyright (c) 2017 Waveshare
+Copyright (c) 2018 Mike Causer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from micropython import const
+from time import sleep_ms
+import ustruct
+
+# Display resolution
+EPD_WIDTH  = const(128)
+EPD_HEIGHT = const(296)
+
+# Display commands
+DRIVER_OUTPUT_CONTROL                = const(0x01)
+BOOSTER_SOFT_START_CONTROL           = const(0x0C)
+#GATE_SCAN_START_POSITION             = const(0x0F)
+DEEP_SLEEP_MODE                      = const(0x10)
+DATA_ENTRY_MODE_SETTING              = const(0x11)
+SW_RESET                             = const(0x12)
+#TEMPERATURE_SENSOR_CONTROL           = const(0x1A)
+MASTER_ACTIVATION                    = const(0x20)
+DISPLAY_UPDATE_CONTROL_1             = const(0x21)
+DISPLAY_UPDATE_CONTROL_2             = const(0x22)
+WRITE_RAM                            = const(0x24)
+WRITE_VCOM_REGISTER                  = const(0x2C)
+WRITE_LUT_REGISTER                   = const(0x32)
+SET_DUMMY_LINE_PERIOD                = const(0x3A)
+SET_GATE_TIME                        = const(0x3B)
+BORDER_WAVEFORM_CONTROL              = const(0x3C)
+SET_RAM_X_ADDRESS_START_END_POSITION = const(0x44)
+SET_RAM_Y_ADDRESS_START_END_POSITION = const(0x45)
+SET_RAM_X_ADDRESS_COUNTER            = const(0x4E)
+SET_RAM_Y_ADDRESS_COUNTER            = const(0x4F)
+TERMINATE_FRAME_READ_WRITE           = const(0xFF)
+
+BUSY = const(1)  # 1=busy, 0=idle
+
+class EPD:
+    GENERATION = 2
+    def __init__(self, spi, cs, dc, rst, busy, appcfg=None):
+        self.spi = spi
+        self.cs = cs
+        self.dc = dc
+        self.rst = rst
+        self.busy = busy
+        self.cs.init(self.cs.OUT, value=1)
+        self.dc.init(self.dc.OUT, value=0)
+        self.rst.init(self.rst.OUT, value=0)
+        self.busy.init(self.busy.IN)
+        self.width = EPD_WIDTH
+        self.height = EPD_HEIGHT
+
+        # Default to 1 (always full refresh) if not set
+        extras = getattr(appcfg, "DRIVER_EXTRAS", {})
+        v2_cfg = extras.get("epaper2in9_V2", {})
+        self.full_refresh_interval = v2_cfg.get("FULL_REFRESH_INTERVAL", 1)
+        self.refresh_count = 0
+        self.update_time = ""
+        print(f"DEBUG: Driver initialized. Full refresh every {self.full_refresh_interval} updates.")
+
+    # Reference: https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd2in9_V2.py
+    WS_20_30 = bytearray(b'\x80\x66\x00\x00\x00\x00\x00\x00\x40\x00\x00\x00\x10\x66\x00\x00\x00\x00\x00\x00\x20\x00\x00\x00\x80\x66\x00\x00\x00\x00\x00\x00\x40\x00\x00\x00\x10\x66\x00\x00\x00\x00\x00\x00\x20\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14\x08\x00\x00\x00\x00\x02\x0A\x0A\x00\x0A\x0A\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x14\x08\x00\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x44\x44\x44\x44\x44\x44\x00\x00\x00\x22\x17\x41\x00\x32\x36')
+    WF_FULL = bytearray(b'\x90\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x60\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x90\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x60\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x19\x19\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x24\x42\x22\x22\x23\x32\x00\x00\x00\x22\x17\x41\xAE\x32\x38')
+    WF_PARTIAL = bytearray(b'\x00\x40\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x40\x40\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0A\x00\x00\x00\x00\x00\x01\x01\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x22\x22\x22\x22\x22\x22\x00\x00\x00\x22\x17\x41\xB0\x32\x36\x00\x00\x00\x00\x00\x00')
+
+    def _command(self, command, data=None):
+        self.dc(0)
+        self.cs(0)
+        self.spi.write(bytearray([command]))
+        self.cs(1)
+        if data is not None:
+            self._data(data)
+
+    def _data(self, data):
+        self.dc(1)
+        self.cs(0)
+        self.spi.write(data)
+        self.cs(1)
+
+    def _init_full(self):
+        self.reset()
+        self.wait_until_idle()
+        self._command(SW_RESET)
+        self.wait_until_idle()
+
+        self._command(DRIVER_OUTPUT_CONTROL, b'\x27\x01\x00')
+        self._command(DATA_ENTRY_MODE_SETTING, b'\x03')
+        
+        # Set Window
+        self._command(SET_RAM_X_ADDRESS_START_END_POSITION, bytes([0, (self.width - 1) >> 3]))
+        self._command(SET_RAM_Y_ADDRESS_START_END_POSITION, bytes([0, 0, (self.height - 1) & 0xFF, (self.height - 1) >> 8]))
+        
+        # Display Update Control 1
+        self._command(DISPLAY_UPDATE_CONTROL_1, b'\x00\x80')
+        
+        # Set Cursor
+        self._command(SET_RAM_X_ADDRESS_COUNTER, b'\x00')
+        self._command(SET_RAM_Y_ADDRESS_COUNTER, b'\x00\x00')
+        
+        # Enable internal LUT and refresh
+        self._command(DISPLAY_UPDATE_CONTROL_2, b'\xB1') 
+
+        self.set_lut(self.WS_20_30)
+
+    def _init_fast(self):
+        self.reset()
+        self.wait_until_idle()
+        self._command(SW_RESET)
+        self.wait_until_idle()
+
+        self._command(DRIVER_OUTPUT_CONTROL, b'\x27\x01\x00')
+        self._command(DATA_ENTRY_MODE_SETTING, b'\x03')
+        
+        self.set_memory_area(0, 0, self.width - 1, self.height - 1)
+        self.set_memory_pointer(0, 0)
+
+        self._command(BORDER_WAVEFORM_CONTROL, b'\x05')
+        self._command(DISPLAY_UPDATE_CONTROL_1, b'\x00\x80')
+        
+        self.wait_until_idle()
+        self.set_lut(self.WF_FULL)
+
+    def _display_partial(self, image, old_image=None):
+        """
+        Execute partial update.
+        If old_image is provided, uses 0x26 command to minimize ghosting.
+        """
+        # Hardware Reset (2ms sequence)
+        self.rst(0)
+        sleep_ms(2)
+        self.rst(1)
+        sleep_ms(2)
+        self.wait_until_idle()
+        
+        # LUT and Border Configuration
+        self.set_lut(self.WF_PARTIAL)
+        self._command(0x37, b'\x00\x00\x00\x00\x00\x40\x00\x00\x00\x00')
+        self._command(BORDER_WAVEFORM_CONTROL, b'\x80')
+        
+        # Power and Clock Activation Process
+        self._command(DISPLAY_UPDATE_CONTROL_2, b'\xC0')
+        self._command(MASTER_ACTIVATION)
+        self.wait_until_idle()
+
+        # RAM Address and Counter
+        self.set_memory_area(0, 0, self.width - 1, self.height - 1)
+        self.set_memory_pointer(0, 0)
+        
+        # 0x24: Write New Data to RAM
+        self._command(WRITE_RAM, image)     
+        
+        # 0x26: Write Old Data to RAM (History for differential update)
+        if old_image is not None:
+            self._command(0x26, old_image)
+            print("DEBUG: History-based update enabled (0x26)")
+        
+        # Execute Display Update
+        self._command(DISPLAY_UPDATE_CONTROL_2, b'\x0F') 
+        self._command(MASTER_ACTIVATION)
+        self.wait_until_idle()
+
+    def init(self):
+        self.reset()
+        self.wait_until_idle()
+
+    def wait_until_idle(self):
+        while self.busy.value() == BUSY:
+            sleep_ms(100)
+
+    def reset(self):
+        self.rst(0)
+        sleep_ms(200)
+        self.rst(1)
+        sleep_ms(200)
+
+    def set_lut(self, lut):
+        self._command(WRITE_LUT_REGISTER, lut[:153])
+        self.wait_until_idle()
+
+        self._command(0x3f, bytes([lut[153]]))
+        self._command(0x03, bytes([lut[154]])) # gate voltage
+        self._command(0x04, bytes([lut[155], lut[156], lut[157]])) # source voltage
+        self._command(0x2c, bytes([lut[158]])) # VCOM
+        self.wait_until_idle()
+
+    # put an image in the frame memory
+    def set_frame_memory(self, image, x, y, w, h):
+        # x point must be the multiple of 8 or the last 3 bits will be ignored
+        x = x & 0xF8
+        w = w & 0xF8
+
+        if (x + w >= self.width):
+            x_end = self.width - 1
+        else:
+            x_end = x + w - 1
+
+        if (y + h >= self.height):
+            y_end = self.height - 1
+        else:
+            y_end = y + h - 1
+
+        self.set_memory_area(x, y, x_end, y_end)
+        self.set_memory_pointer(x, y)
+        self._command(WRITE_RAM, image)
+
+    # replace the frame memory with the specified color
+    def clear_frame_memory(self, color):
+        print("clear_frame_memory", color)
+        self.set_memory_area(0, 0, self.width - 1, self.height - 1)
+        self.set_memory_pointer(0, 0)
+        self._command(WRITE_RAM)
+        # send the color data
+        for i in range(0, self.width // 8 * self.height):
+            b = bytearray([color])
+            self._data(b)
+
+    # draw the current frame memory and switch to the next memory area
+    def display_frame(self, image, old_image=None):
+        if self.refresh_count == 0:
+            print("Action: Executing Full Refresh...")
+            self._init_full()
+            self.set_memory_area(0, 0, self.width - 1, self.height - 1)
+            self.set_memory_pointer(0, 0)
+            self._command(WRITE_RAM, image)
+            self._command(DISPLAY_UPDATE_CONTROL_2, b'\xF7')
+            self._command(MASTER_ACTIVATION)
+            self.wait_until_idle()
+            self.refresh_count = 1
+        else:
+            print(f"Action: Executing Partial Refresh ({self.refresh_count}/{self.full_refresh_interval})")
+            self._display_partial(image, old_image)
+            self.refresh_count += 1
+            if self.refresh_count >= self.full_refresh_interval:
+                self.refresh_count = 0
+
+    # specify the memory area for data R/W
+    def set_memory_area(self, x_start, y_start, x_end, y_end):
+        self._command(SET_RAM_X_ADDRESS_START_END_POSITION)
+        # x point must be the multiple of 8 or the last 3 bits will be ignored
+        self._data(bytearray([(x_start >> 3) & 0xFF]))
+        self._data(bytearray([(x_end >> 3) & 0xFF]))
+        self._command(SET_RAM_Y_ADDRESS_START_END_POSITION, ustruct.pack("<HH", y_start, y_end))
+
+    # specify the start point for data R/W
+    def set_memory_pointer(self, x, y):
+        self._command(SET_RAM_X_ADDRESS_COUNTER)
+        # x point must be the multiple of 8 or the last 3 bits will be ignored
+        self._data(bytearray([(x >> 3) & 0xFF]))
+        self._command(SET_RAM_Y_ADDRESS_COUNTER, ustruct.pack("<H", y))
+        self.wait_until_idle()
+
+    # to wake call reset() or init()
+    def sleep(self):
+        self.wait_until_idle()
+        self._command(DEEP_SLEEP_MODE, b'\x01')
+
+    def draw_debug_overlay(self, scr):
+        count_text = f"{self.refresh_count}/{self.full_refresh_interval}"
+        debug_text = f"{count_text} {self.update_time}" if self.update_time else count_text
+        scr.printat(debug_text, 2, 2)

--- a/esp32/board/main.py
+++ b/esp32/board/main.py
@@ -4,8 +4,9 @@ from eink import EInk
 from led import Led,LedDummy
 from esp32_regs import GetResetCauseText
 
+import sys
 import time
-from machine import deepsleep,reset
+from machine import deepsleep,lightsleep,reset
 
 
 def print_message(text=None):
@@ -31,8 +32,11 @@ def print_error(text):
     print("Sleep %i sec" % error_sleep_sec)
     time.sleep(error_sleep_sec)
     
-    
-
+def start_sleep(ms, mode):
+    if mode == "light":
+        lightsleep(ms)
+    else:
+        deepsleep(ms)
 
 cfg = AppConfig()
 #led = Led(cfg.PIN_LED)
@@ -49,29 +53,23 @@ print("------")
 error_count = 0
 
 while (True):
-    
-    
-    errortext = ""
+    img = None
+    update_time = ""
     try:
-        rc = wlan.connect()
+        img, update_time = wlan.load()
     except Exception as e:
-        errortext = str(e)
-        rc=False
-
-   
-    if (not rc):
-        print_error("WiFi connection failed."+errortext)
-        continue
+        print_error(f"Image load failed: {e}")
     
-    try:
-        img = wlan.load()
-    except Exception as e:
-        print_error("\n  Image load failed.\n  "+str(e)+"\n" )
-        continue
-
-    error_count = 0
-    assert img!=None
-    eink.show(img)
+    if img:
+        error_count = 0
+        eink.show(img, update_time=update_time)
+    else:
+        print("Skipping display update due to error.")
     
-    print("Deep sleep %i sec" % (cfg.IMAGE_RELOAD_PERIOD_MS/1000))
-    deepsleep(cfg.IMAGE_RELOAD_PERIOD_MS)
+    sleep_ms = cfg.IMAGE_RELOAD_PERIOD_MS
+    sleep_mode = eink.sleep_mode
+    print("Entering system %s sleep for %i sec..." % (sleep_mode, sleep_ms / 1000))
+    if hasattr(sys, 'stdout') and hasattr(sys.stdout, 'flush'):
+        sys.stdout.flush()
+    time.sleep_ms(100)
+    start_sleep(sleep_ms, sleep_mode)

--- a/esp32/board/wifi.py
+++ b/esp32/board/wifi.py
@@ -1,76 +1,176 @@
 import network
 import urequests
 import time
+import socket
+import gc
 
-def lebytes_to_int(bytes):
-    return int.from_bytes(bytes, 'little')
-
+def lebytes_to_int(data):
+    return int.from_bytes(data, 'little')
 
 class WiFi:
-    
-    
-    def __init__(self,appcfg,led):
+    def __init__(self, appcfg, led):
         self.led = led
         self.cfg = appcfg
         self.wlan = network.WLAN(network.STA_IF)
         self.wlan.active(True)
         print("WiFi init")
-        
-        
-    def connect(self):
-        if self.wlan.isconnected():
-            print("WiFi already connected: ", self.wlan.ifconfig())
-            self.led.blink(1)
-            return True
+
+    def get_ip(self):
+        try:
+            return self.wlan.ifconfig()[0]
+        except:
+            return '0.0.0.0'
+
+    def connect(self, force_reconnect=False):
+        """
+        Establishes a WiFi connection.
+        If force_reconnect is True, waits for the stack to fully disconnect 
+        to ensure the next connection is fresh.
+        """
+        if not force_reconnect:
+            if self.wlan.isconnected() and self.get_ip() != '0.0.0.0':
+                self.led.blink(1)
+                return True
+        else:
+            # Wait for the network stack to realize it is disconnected
+            print("Ensuring clean disconnection...")
+            for _ in range(10): # Max 1s wait
+                if not self.wlan.isconnected():
+                    break
+                time.sleep_ms(100)
             
         self.led.blink()
-        print('Trying to connect to %s...' % self.cfg.AP_SSID)
-        self.wlan.connect(self.cfg.AP_SSID, self.cfg.AP_PASS )
+        print(f'Connecting to {self.cfg.AP_SSID}... ', end='')
+        self.wlan.connect(self.cfg.AP_SSID, self.cfg.AP_PASS)
+        
+        connected = False
         for retry in range(200):
             connected = self.wlan.isconnected()
             if connected:
                 break
             time.sleep(0.1)
             print('.', end='')
+        print()
+            
         if connected:
-            print('\nConnected. Network config: ', self.wlan.ifconfig())
-            self.led.off()
+            return self.wait_network_ready()
         else:
-            print('\nFailed.')
+            print('Connection Failed.')
             self.led.flash()
-            
-        return connected
+            return False
     
-    
-    def load(self):
-        
-        self.led.blink()
-        print("Loading "+self.cfg.URL)
+    def wait_network_ready(self):
+        """Poll until a valid IP address is assigned by DHCP"""
+        print("Waiting for IP address...")
+        for i in range(20):  # Max 4 seconds
+            if self.wlan.isconnected():
+                ip = self.get_ip()
+                if ip != "0.0.0.0":
+                    print("Network ready:", ip)
+                    try:
+                        self.wlan.config(pm=network.WLAN.PM_NONE)
+                    except:
+                        pass
+                    # Stabilization delay
+                    time.sleep_ms(500)
+                    self.led.off()
+                    return True
+            time.sleep(0.2)
+        print("Network not ready (timeout)")
+        return False
+
+    def warmup(self, url):
+        """Establish routing by performing a dummy TCP connection to prevent EHOSTUNREACH"""
         try:
-            r = urequests.get(self.cfg.URL, headers={'accept': 'image/bmp'})
-            print("Image loaded")
-        finally:
-            self.led.off()            
-    
-        if (r==None) or (r.content==None):
-            raise Exception("Image file load error")
-        if (len(r.content)<54):
-            raise Exception("Image file too small")
-    
-        img_bytes = r.content
-        start_pos = lebytes_to_int(img_bytes[10:14])
-        end_pos = start_pos + lebytes_to_int(img_bytes[34:38])
-        width = lebytes_to_int(img_bytes[18:22])
-        height = lebytes_to_int(img_bytes[22:26])
-        
-        if (width!=self.cfg.SCR_WIDTH) or (height!=self.cfg.SCR_HEIGHT):
-            raise Exception("Wrong image size %ix%i, expected %ix%i" % (width,height,self.cfg.SCR_WIDTH,self.cfg.SCR_HEIGHT))
-        
+            temp_url = url.split("://")[-1]
+            host_part = temp_url.split("/")[0]
+            if ":" in host_part:
+                host, port_str = host_part.split(":")
+                port = int(port_str)
+            else:
+                host = host_part
+                port = 443 if url.startswith("https") else 80
+                
+            print(f"Warming up connection to {host}:{port}...")
+            addr = socket.getaddrinfo(host, port)[0][-1]
+            s = socket.socket()
+            s.settimeout(2)
+            s.connect(addr)
+            s.close()
+            time.sleep_ms(200)
+        except Exception as e:
+            print(f"Warmup skipped: {e}")
+            pass
 
-
-        return img_bytes[start_pos:]
-            
-            
-
+    def load(self):
+        max_retries = 2
+        img_bytes = None
         
-    
+        for attempt in range(max_retries):
+            r = None
+            try:
+                # Refresh logic
+                force_reconnect = False
+                if attempt == 0 and self.wlan.isconnected():
+                    print("Refreshing connection for stable session...")
+                    self.wlan.disconnect()
+                    force_reconnect = True
+                
+                # Establish connection
+                if not self.connect(force_reconnect=force_reconnect):
+                    raise Exception("WiFi Connection Failed")
+                
+                # Pre-verify path
+                self.warmup(self.cfg.URL)
+
+                self.led.blink()
+                print(f"Loading {self.cfg.URL} (Attempt {attempt+1}/{max_retries})")
+                
+                r = urequests.get(self.cfg.URL, headers={'accept': 'image/bmp'}, timeout=15)
+                
+                # Debug Overlay: Extract and format server timestamp
+                formatted_date = ""
+                if self.cfg.DEBUG_OVERLAY:
+                    raw_date = r.headers.get('Date', '')
+                    print(f"Server Date: {raw_date}")
+                    if raw_date:
+                        parts = raw_date.split(' ')
+                        if len(parts) >= 6:
+                            formatted_date = f"{parts[4][:5]}{parts[5]}"  # "21:37GMT"
+                            
+                img_bytes = r.content
+                if (img_bytes is None) or (len(img_bytes) < 54):
+                    raise Exception("Invalid image data")
+
+                print("Image loaded successfully")
+                self.led.off()
+                
+                # BMP Header validation
+                start_pos = lebytes_to_int(img_bytes[10:14])
+                # Ensure the offset is within the downloaded data
+                if start_pos >= len(img_bytes):
+                    raise Exception(f"Invalid BMP offset: {start_pos} / {len(img_bytes)}")
+                
+                width = lebytes_to_int(img_bytes[18:22])
+                height = lebytes_to_int(img_bytes[22:26])
+                
+                if (width != self.cfg.SCR_WIDTH) or (height != self.cfg.SCR_HEIGHT):
+                    raise Exception(f"Size mismatch: {width}x{height}")
+
+                return img_bytes[start_pos:], formatted_date
+
+            except Exception as e:
+                self.led.flash()
+                print(f"\nLoad failed: {e}")
+                
+                if attempt < max_retries - 1:
+                    print("Force resetting WiFi hardware for retry...")
+                    self.wlan.active(False)
+                    time.sleep_ms(300)
+                    self.wlan.active(True)
+                else:
+                    raise
+            finally:
+                if r:
+                    r.close()
+                gc.collect()


### PR DESCRIPTION
# Add support for Waveshare 2.9" e-Paper V2 (GDEY029T94) with partial refresh

## Summary

This PR adds support for the **Waveshare 2.9" Black/White e-Paper V2 (GDEY029T94)** display module, which requires a different initialization and refresh sequence from the original V1 driver. It also refactors the driver loading mechanism to be fully dynamic, so future drivers can be added by simply dropping a new `.py` file and updating `appconfig.py`.

---

## Changes

### New file: `epaper2in9_V2.py`

A new MicroPython driver for the GDEY029T94 panel.

**Key features:**
- `GENERATION = 2` class attribute — allows `eink.py` to auto-detect driver capabilities at runtime
- Three LUT waveform tables:
  - `WS_20_30` — standard waveform (used during full init)
  - `WF_FULL` — fast full refresh
  - `WF_PARTIAL` — partial refresh for low-flicker incremental updates
- **Automatic full/partial refresh switching** in `display_frame()` based on a configurable `FULL_REFRESH_INTERVAL` counter. Every N partial updates, one full refresh is performed to clear ghosting
- **History-based differential update**: writes the previous frame to register `0x26` during partial refresh, enabling the panel's hardware differencing to minimize ghosted pixels
- `sleep()` — deep sleep via `DEEP_SLEEP_MODE` command
- `draw_debug_overlay(scr)` — draws refresh count and server timestamp onto the screen buffer when debug mode is enabled
- Accepts `appcfg` in constructor to read `DRIVER_EXTRAS` settings

---

### Modified: `appconfig.py`

| Addition | Description |
|---|---|
| `EPD_DRIVER` | Selects the driver module by name as a string (e.g. `"epaper2in9"` or `"epaper2in9_V2"`). Default is `"epaper2in9"` to preserve backward compatibility. |
| `DRIVER_EXTRAS` | Dict of driver-specific extended settings. V2 supports `FULL_REFRESH_INTERVAL` (partial updates before forced full refresh) and `SLEEP_MODE` (`"light"` or `"deep"`). |
| `DEBUG_OVERLAY` | Boolean flag. When `True`, draws the refresh counter and server response timestamp onto the display. |

---

### Modified: `eink.py`

- **Dynamic driver loading**: uses `__import__(cfg.EPD_DRIVER)` to load any driver by name. No more hardcoded imports.
- **Constructor compatibility**: tries the V2-style `EPD(spi, cs, dc, rst, busy, cfg)` constructor first; falls back to V1-style `EPD(spi, cs, dc, rst, busy)` on `TypeError`. Existing V1 drivers work without modification.
- **Generation detection**: reads `getattr(self.dev, 'GENERATION', 1)` — defaults to 1 for all existing drivers.
- **`show()` method** now dispatches two strategies:
  - **V2 strategy**: calls `dev.init()` to wake the panel, then `dev.display_frame(current_frame, old_data)`. Full/partial decision is delegated entirely to the driver. Maintains `old_data` state for differential updates.
  - **V1 strategy (legacy)**: original `set_frame_memory` / `display_frame()` path. No behavioral change for V1 users.
- **`sleep_panel()`** method added — calls `dev.sleep()` if supported.
- Debug overlay rendering integrated into the V2 update path.

---

### Modified: `main.py`

- **`start_sleep(ms, mode)`** helper — dispatches to `lightsleep()` or `deepsleep()` based on `eink.sleep_mode`, which is read from `DRIVER_EXTRAS`. Previously hardcoded to `deepsleep`.
- `wlan.load()` now returns a `(img, update_time)` tuple; `update_time` is forwarded to `eink.show()` for the debug overlay.

---

### Modified: `wifi.py`

- **`connect(force_reconnect)`**: new parameter. When `True`, waits up to 1 second for the network stack to fully disconnect before reconnecting, ensuring a clean session after sleep.
- **`load()`**: now explicitly disconnects at the start of each load cycle to avoid stale DHCP leases causing silent failures after deep sleep.
- **`warmup(url)`**: new method. Opens a short-lived TCP connection to the target host before the actual HTTP request. Prevents `EHOSTUNREACH` errors that can occur immediately after WiFi reconnection while routing tables are still being populated.
- **WiFi hardware reset on retry**: on a failed attempt, calls `wlan.active(False)` then `wlan.active(True)` before the next retry to fully reset the WiFi peripheral.
- **`wait_network_ready()`**: polls until a non-zero IP is assigned, then sets `PM_NONE` to disable WiFi power-save mode, which can cause packet loss on some APs.
- **Server timestamp extraction**: parses the HTTP `Date` response header into a compact `HH:MMzone` string (e.g. `21:37GMT`) and returns it alongside the image bytes for the debug overlay.
- Return type changed from `img_bytes` to `(img_bytes, formatted_date)` tuple.

---

## Backward Compatibility

All changes are fully backward compatible with the existing `epaper2in9` V1 driver:

- `EPD_DRIVER` defaults to `"epaper2in9"`
- `DRIVER_EXTRAS` is optional; V2-specific keys are only read when the V2 driver is active
- `eink.py` falls back to the V1 constructor and update path automatically
- `DEBUG_OVERLAY` defaults to `False`

**No changes are required for existing users of the original driver.**

---

## How to use the V2 driver

1. Copy `epaper2in9_V2.py` to the ESP32 board alongside the other files.
2. In `appconfig.py`, set:

```python
EPD_DRIVER = "epaper2in9_V2"

DRIVER_EXTRAS = {
    "epaper2in9_V2": {
        "FULL_REFRESH_INTERVAL": 15,  # Full refresh every 15 partial updates
        "SLEEP_MODE": "light"         # "light" or "deep"
    }
}
```

3. Upload all files. No other changes needed.

---

## Tested with

- Hardware: Waveshare 2.9inch e-Paper Module V2 (GDEY029T94)
- Board: ESP32-DevKitC-32E (MicroPython v1.27.0)
