### PR TITLE
Add Fahrenheit temperature unit config options

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -57,3 +57,25 @@ class WLConfig_RGB_Black(WLConfig_RGB_White):
     COLOR_FG =     (255,255,255)
     COLOR_RAIN = (122, 213, 255)
     COLOR_SNOW = (255,255,255)    
+
+# ── Fahrenheit variants ──────────────────────────────────────────────────
+
+class WLConfig_BW_F(WLConfig_BW):
+    TITLE = "BW °F"
+    TEMPUNITS_MODE = 1
+
+class WLConfig_EINK_F(WLConfig_EINK):
+    TITLE = "BW EINK °F"
+    TEMPUNITS_MODE = 1
+
+class WLConfig_BWI_F(WLConfig_BWI):
+    TITLE = "BW inverted °F"
+    TEMPUNITS_MODE = 1
+
+class WLConfig_RGB_White_F(WLConfig_RGB_White):
+    TITLE = "Color °F, white BG"
+    TEMPUNITS_MODE = 1
+
+class WLConfig_RGB_Black_F(WLConfig_RGB_Black):
+    TITLE = "Color °F, black BG"
+    TEMPUNITS_MODE = 1

--- a/configs.py
+++ b/configs.py
@@ -62,20 +62,25 @@ class WLConfig_RGB_Black(WLConfig_RGB_White):
 
 class WLConfig_BW_F(WLConfig_BW):
     TITLE = "BW °F"
+    OUT_FILENAME = "landscape_wb_f"
     TEMPUNITS_MODE = 1
 
 class WLConfig_EINK_F(WLConfig_EINK):
     TITLE = "BW EINK °F"
+    OUT_FILENAME = "landscape_eink_f"
     TEMPUNITS_MODE = 1
 
 class WLConfig_BWI_F(WLConfig_BWI):
     TITLE = "BW inverted °F"
+    OUT_FILENAME = "landscape_wbi_f"
     TEMPUNITS_MODE = 1
 
 class WLConfig_RGB_White_F(WLConfig_RGB_White):
     TITLE = "Color °F, white BG"
+    OUT_FILENAME = "landscape_rgb_w_f"
     TEMPUNITS_MODE = 1
 
 class WLConfig_RGB_Black_F(WLConfig_RGB_Black):
     TITLE = "Color °F, black BG"
+    OUT_FILENAME = "landscape_rgb_b_f"
     TEMPUNITS_MODE = 1

--- a/run_server.py
+++ b/run_server.py
@@ -24,6 +24,12 @@ WEATHERS = [    WeatherLandscape(WLConfig_BW())          ,
                 WeatherLandscape(WLConfig_EINK())        ,
                 WeatherLandscape(WLConfig_RGB_Black())   ,
                 WeatherLandscape(WLConfig_RGB_White())   ,
+                # ── Fahrenheit variants ──
+                WeatherLandscape(WLConfig_BW_F())        ,
+                WeatherLandscape(WLConfig_BWI_F())       ,
+                WeatherLandscape(WLConfig_EINK_F())      ,
+                WeatherLandscape(WLConfig_RGB_Black_F()) ,
+                WeatherLandscape(WLConfig_RGB_White_F()) ,
                 ]
                 
 

--- a/run_test.py
+++ b/run_test.py
@@ -14,6 +14,13 @@ cfgs =  [
          
           WLConfig_RGB_Black(),          
           WLConfig_RGB_White(),
+
+          # ── Fahrenheit variants ──
+          WLConfig_BW_F(),
+          WLConfig_BWI_F(),
+          WLConfig_EINK_F(),
+          WLConfig_RGB_Black_F(),
+          WLConfig_RGB_White_F(),
           ]
           
 


### PR DESCRIPTION
Adds Fahrenheit (ºF) config variants for all existing display configurations.

- Created WLConfig_BW_F, WLConfig_EINK_F, WLConfig_BWI_F, WLConfig_RGB_White_F, WLConfig_RGB_Black_F
- Each uses TEMPUNITS_MODE=1 and a distinct output filename (_f suffix)
- The existing Celsius infrastructure (IsCelsius, PrintableTemperature, toFahrenheit) was already in place, just needed config wiring
- Updated server and test runners to include the new variants

Tested on a Raspberry Pi with the weather display.